### PR TITLE
Phyloseq to metabar

### DIFF
--- a/source/r/check_presence.R
+++ b/source/r/check_presence.R
@@ -16,7 +16,7 @@ check_presence <- function(
     countries = c("BE", "FR", "DE", "LU", "NL", "CH", "AT")) {
   require(dplyr)
   require(purrr)
-  if (!is.null(input) && file.exists(input)) {
+  if (length(input) == 1 && !is.null(input) && file.exists(input)) {
     # Read scientific names from the input file
     scientific_names <- readLines(input)
   } else if (is.character(input)) {

--- a/source/r/phyloseq-to-metabar.R
+++ b/source/r/phyloseq-to-metabar.R
@@ -1,5 +1,7 @@
 # Install/load packages
 
+waarom verdwijnt deze commit
+
 # Function to install a package if not already installed
 install_if_missing <- function(package_name) {
   if (!requireNamespace(package_name, quietly = TRUE)) {

--- a/source/r/phyloseq-to-metabar.R
+++ b/source/r/phyloseq-to-metabar.R
@@ -1,0 +1,274 @@
+# Install/load packages
+
+# Function to install a package if not already installed
+install_if_missing <- function(package_name) {
+  if (!requireNamespace(package_name, quietly = TRUE)) {
+    install.packages(package_name, dependencies = TRUE)
+  }
+}
+
+# List of packages to load
+packages_to_load <- c("igraph", "ggplot2", "dplyr", "tidyr",
+                      "biomformat", "metabaR", "phyloseq",
+                      "microbiome", "biom", "data.table")
+
+# Load packages
+for(package_name in packages_to_load) {
+  library(package_name, character.only = TRUE)
+}
+
+################################################################################
+# Function to download and source R script
+download_and_source <- function(url, destination) {
+  if (!file.exists(destination)) {
+    download.file(url, destination, mode = "wb")
+  }
+  source(destination)
+}
+
+# Download and source microfiltR_source_code.R
+download_and_source("https://raw.githubusercontent.com/itsmisterbrown/microfiltR/master/microfiltR_source_code.R", "microfiltR_source_code.R")
+
+# Download and source check_metabarlist.R
+download_and_source("https://raw.githubusercontent.com/metabaRfactory/metabaR/HEAD/R/check_metabarlist.R", "check_metabarlist.R")
+
+# Download and source subset_metabarlist.R
+download_and_source("https://raw.githubusercontent.com/metabaRfactory/metabaR/HEAD/R/subset_metabarlist.R", "subset_metabarlist.R")
+
+# Download and source ggtaxplot.R
+download_and_source("https://raw.githubusercontent.com/slambrechts/metabaR/master/R/ggtaxplot.R", "ggtaxplot.R")
+
+################################################################################
+# Set working directory
+
+#setwd("G:/path/to/working/directory")
+
+################################################################################
+################################################################################
+# Load in Phyloseq Olig01 Annelida MBAG
+load("./physeq_Olig01_Annelida_rar_species.Rdata")
+
+
+fp <- paste(getwd(), "/", sep = "")
+write.dataset(ps = physeq_Olig01_Annelida_rar.rarefied.species, filePATH = fp, filePREFIX = "Olig01_Annelida")
+
+
+################################################################################
+# File reads
+asv_tab <- as.matrix(t(phyloseq::otu_table(physeq_Olig01_Annelida_rar.rarefied.species)))
+file_reads <- as.data.frame(asv_tab)
+
+# Make numeric columns numeric
+str(file_reads)
+
+file_reads_num <- file_reads
+file_reads_num[] <- as.data.frame(sapply(file_reads, as.numeric))
+str(file_reads_num)
+
+# create matrix
+file_reads_num_matrix <- as.matrix(file_reads_num)
+class(file_reads_num_matrix)
+
+# Add _r1 to the row names
+# adding suffix to row names
+rownames(file_reads_num_matrix) <- paste(rownames(file_reads_num_matrix),"r1",sep = "_")
+
+
+# Save file
+write.table(file_reads_num_matrix, file = "Olig01_Annelida_ASV_table_transpose.txt", sep = "\t",
+            row.names = TRUE)
+
+
+################################################################################
+#file pcrs (moet eerst nog  aangemaakt worden)
+
+
+# Assuming your data is stored in a matrix or a data frame named 'your_data'
+# First, create a dataframe with the first two columns
+df_pcr <- data.frame(
+  pcr_id = rownames(file_reads_num_matrix),
+  sample_id = sub("_r1$", "", rownames(file_reads_num_matrix)),
+  stringsAsFactors = FALSE
+)
+
+# Add the last two columns
+df_pcr$type <- "sample"
+df_pcr$control_type <- NA
+
+# create matrix
+file_pcrs_matrix <- as.matrix(df_pcr)
+class(file_pcrs_matrix)
+
+# Save file
+write.table(file_pcrs_matrix, file = "Olig01_Annelida_PCRs.txt", sep = "\t",
+            row.names = FALSE)
+
+################################################################################
+# file samples
+
+file_samples <- suppressWarnings(as.matrix(phyloseq::sample_data(physeq_Olig01_Annelida_rar.rarefied.species)))
+
+# create matrix
+file_samples_matrix <- as.matrix(file_samples)
+class(file_samples_matrix)
+
+# Save file
+write.table(file_samples_matrix, file = "Olig01_Annelida_sample_data2.txt", sep = "\t",
+            row.names = TRUE)
+
+################################################################################
+# File motus
+
+# Belangrijk! De sequenties moeten op 1 lijn staan per OTU in de sequentie file (olig01_otus92_mbag.fa)
+
+
+# Read taxonomy table from physeq
+tax.tab <- as.data.frame(phyloseq::tax_table(physeq_Olig01_Annelida_rar.rarefied.species))
+
+# Create a taxonomy dictionary
+taxonomy_dict <- list()
+for (i in 1:nrow(tax.tab)) {
+  otu <- rownames(tax.tab)[i]
+  taxonomy <- paste(na.omit(tax.tab[i, ]), collapse = ";")
+  taxonomy_dict[[otu]] <- taxonomy
+}
+
+# Process the input file and create the output file
+input_file <- file("olig01_otus92_mbag.fa", "r")
+output_file <- file("Olig01_Annelida_motus_seq.txt", "w")
+
+# Add new column names
+new_column_names <- c("#ASVID", "taxonomy", "sequence")
+
+# Write column names to the output file
+writeLines(paste(new_column_names, collapse = "\t"), output_file)
+
+# Create an empty dataframe to store the data
+output_df <- data.frame(matrix(ncol = length(new_column_names), nrow = 0))
+colnames(output_df) <- new_column_names
+
+current_otu <- NULL
+current_sequence <- NULL
+
+while (length(line <- readLines(input_file, n = 1)) > 0) {
+  if (substr(line, 1, 1) == ">") {
+    if (!is.null(current_otu)) {
+      if (current_otu %in% names(taxonomy_dict) && !is.null(current_sequence)) {
+        # Write to file
+        writeLines(paste(current_otu, taxonomy_dict[[current_otu]], current_sequence, sep = "\t"), output_file)
+        # Add to dataframe
+        new_row <- c(current_otu, taxonomy_dict[[current_otu]], current_sequence)
+        output_df <- rbind(output_df, new_row)
+      }
+    }
+    current_otu <- gsub(">", "", trimws(line))
+    current_sequence <- NULL
+  } else {
+    current_sequence <- paste(current_sequence, trimws(line), sep = "")
+  }
+}
+
+# Add the last record if it's in the taxonomy file and has a sequence
+if (!is.null(current_otu) && current_otu %in% names(taxonomy_dict) && !is.null(current_sequence)) {
+  # Write to file
+  writeLines(paste(current_otu, taxonomy_dict[[current_otu]], current_sequence, sep = "\t"), output_file)
+  # Add to dataframe
+  new_row <- c(current_otu, taxonomy_dict[[current_otu]], current_sequence)
+  output_df <- rbind(output_df, new_row)
+}
+
+close(input_file)
+close(output_file)
+
+# Assigning new column names to output_df
+colnames(output_df) <- new_column_names
+
+
+# Now you can use 'output_df' as your dataframe for further processing.
+
+class(output_df)
+
+file_motus <- as.data.frame(output_df)
+
+
+#redefine row names
+rownames(file_motus) <- file_motus[, 1]
+file_motus <- file_motus[ ,-1]
+
+
+# Reorder the OTU_ names
+# Extract numeric part from row names
+row_numbers <- as.numeric(gsub("OTU_", "", rownames(file_motus)))
+
+# Sort row names based on numeric values
+sorted_row_names <- rownames(file_motus)[order(row_numbers)]
+
+# Reorder the data frame using sorted row names
+sorted_data_motus <- file_motus[sorted_row_names, ]
+
+
+sorted_data_motus <- sorted_data_motus %>%
+  separate(col = taxonomy, sep = ";", into = paste0('Tax', 1:6), fill = 'right')
+
+
+# Rename columns
+rownames(sorted_data_motus) <- rownames(sorted_data_motus)
+colnames(sorted_data_motus) <- c("phylum_name", "class_name", "order_name", "family_name", "genus_name", "species_name", "sequence")
+
+# Rename to NA were needed Wanneer een OTU niet geïdentificeerd is op een bepaald niveau (manueel in google sheet)
+
+motus_NA <- sorted_data_motus
+
+# Function to replace names ending with '_otu' followed by digits with NA
+replace_names <- function(motus_NA) {
+  for (i in 1:ncol(motus_NA)) {
+    motus_NA[, i] <- gsub("\\b\\w+_otu\\d+\\b", NA, motus_NA[, i])
+  }
+  return(motus_NA)
+}
+
+# Call the function to replace names
+motus_NA <- replace_names(motus_NA)
+
+# Create matrix
+
+motus_NA_matrix <- motus_NA
+
+
+write.table(motus_NA_matrix, file = "Olig01_Annelida_motus_NA.txt", sep = "\t",
+            row.names = TRUE)
+
+
+################################################################################
+# Create metabarlist
+Olig01_Annelida_metabarlist <- tabfiles_to_metabarlist(file_reads = "./Olig01_Annelida_ASV_table_transpose.txt", file_motus = "Olig01_Annelida_motus_NA.txt", file_pcrs = "./Olig01_Annelida_PCRs.txt", file_samples = "./Olig01_Annelida_sample_data2.txt", files_sep = "\t")
+
+summary_metabarlist(Olig01_Annelida_metabarlist)
+
+save(Olig01_Annelida_metabarlist,file = "metabarlist_Olig01_Annelida.Rdata")
+
+
+#################################################################################
+#################################################################################
+# VISUALISATIE
+
+# Specify what you need
+indices <- grepl("Annelida", Olig01_Annelida_metabarlist$motus$phylum_name)
+
+Olig01_Annelida <- subset_metabarlist(Olig01_Annelida_metabarlist,
+                                      table = "motus",
+                                      indices = indices
+)
+
+
+
+# Using a taxonomic table
+taxo.col <- c(
+  "phylum_name", "class_name", "order_name",
+  "family_name", "genus_name", "species_name"
+)
+plot <- ggtaxplot(Olig01_Annelida, taxo.col)
+plot
+ggsave("my_plot.pdf", plot = plot, width = 18, height = 10, units = "in")
+
+ggsave("my_plot.png", plot = plot, width = 18, height = 10, units = "in")

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -98,6 +98,9 @@ Filter taxongroep:
 physeq <- subset_taxa(
   physeq,
   phylum == "Annelida")
+
+physeq_rarefied <- rarefy_even_depth(physeq, sample.size = 30780)
+
 ```
 
 
@@ -203,7 +206,6 @@ tidy_physeq$samples %>%
 ## OTU tabel
 
 ```{r verken-otu-data}
-physeq_rarefied <- rarefy_even_depth(physeq, sample.size = 30780)
 
 
 glimpse(otu_table(physeq_rarefied) %>% as.data.frame %>% as_tibble())
@@ -451,7 +453,7 @@ tidy_physeq %>%
 ## Ordinatie
 
 ```{r physec-rarefied}
-physeq_rarefied <- rarefy_even_depth(physeq, sample.size = 30780)
+
 ```
 
 ```{r ordination-vegan}

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -237,6 +237,21 @@ tidy_physeq_rarefied %>%
 ```
 
 ```{r}
+# Create a new combined column
+combined_column <- paste(sample_data(physeq_rarefied)$Landgebruik_MBAG, sample_data(physeq_rarefied)$Diepte, sep = "_")
+
+# Add the new combined column to the sample metadata with the desired name
+sample_data(physeq_rarefied)$Landgebruik_MBAG_diepte <- combined_column
+
+# Update the phyloseq object with the modified sample data
+physeq_rarefied <- merge_phyloseq(physeq_rarefied, sample_data(physeq_rarefied))
+
+
+psadd::plot_krona(physeq_rarefied, "MBAG_Olig01_Annelida_rar_species_alle_stalen_Landgebruik_MBAG_per_diepte", "Landgebruik_MBAG_diepte", trim = T)
+
+```
+
+```{r}
 tidy_physeq_rarefied %>%
   tidytacos::tacoplot_stack(x = Landgebruik_MBAG)
 ```

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -71,7 +71,7 @@ path_naar_bestand <- file.path(
     "statistiek",
     "Annelida",
     "phyloseq",
-    "physeq_Olig01_Annelida_species_mbag.Rdata"
+    "physeq_Olig01_Annelida_species.Rdata"
   )
 
 load(path_naar_bestand)

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -213,8 +213,18 @@ glimpse(otu_table(physeq_rarefied) %>% as.data.frame %>% as_tibble())
 
 ## Taxonomie tabel
 
+
 ```{r verken-taxonomie-data}
 glimpse(tax_table(physeq_rarefied) %>% as.data.frame %>% as_tibble())
+```
+
+```{r GBIF-check-presence}
+
+species <- as.vector(tax_table(physeq)[, "species"])
+species <- species[!grepl("_otu", species)]
+species <- gsub("_", " ", species)
+source("source/r/check_presence.R")
+check_presence(species)
 ```
 
 Unieke en gedeelde taxa per diepte:
@@ -250,6 +260,7 @@ physeq_rarefied <- merge_phyloseq(physeq_rarefied, sample_data(physeq_rarefied))
 psadd::plot_krona(physeq_rarefied, "MBAG_Olig01_Annelida_rar_species_alle_stalen_Landgebruik_MBAG_per_diepte", "Landgebruik_MBAG_diepte", trim = T)
 
 ```
+
 
 ```{r}
 tidy_physeq_rarefied %>%

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -127,6 +127,8 @@ veganobject <- psotu2veg(physeq)
 
 ```{r convert-tidytacos}
 tidy_physeq <- tidytacos::from_phyloseq(physeq)
+tidy_physeq_rarefied <- tidytacos::from_phyloseq(physeq_rarefied)
+
 tidy_physeq <- tidy_physeq %>%
   remove_empty_samples() %>%
   tidytacos::set_rank_names(
@@ -134,6 +136,15 @@ tidy_physeq <- tidy_physeq %>%
   ) %>%
   tidytacos::add_alpha() %>%
   tidytacos::add_total_count()
+
+tidy_physeq_rarefied <- tidy_physeq_rarefied %>%
+  remove_empty_samples() %>%
+  tidytacos::set_rank_names(
+    rank_names = c("phylum", "class", "order", "family", "genus", "species")
+  ) %>%
+  tidytacos::add_alpha() %>%
+  tidytacos::add_total_count()
+
 ```
 
 
@@ -192,41 +203,44 @@ tidy_physeq$samples %>%
 ## OTU tabel
 
 ```{r verken-otu-data}
-glimpse(otu_table(physeq) %>% as.data.frame %>% as_tibble())
+physeq_rarefied <- rarefy_even_depth(physeq, sample.size = 30780)
+
+
+glimpse(otu_table(physeq_rarefied) %>% as.data.frame %>% as_tibble())
 ```
 
 ## Taxonomie tabel
 
 ```{r verken-taxonomie-data}
-glimpse(tax_table(physeq) %>% as.data.frame %>% as_tibble())
+glimpse(tax_table(physeq_rarefied) %>% as.data.frame %>% as_tibble())
 ```
 
 Unieke en gedeelde taxa per diepte:
 
 ```{r}
-tidy_physeq %>%
+tidy_physeq_rarefied %>%
   tidytacos::tacoplot_venn(Diepte)
 ```
 
 Unieke en gedeelde taxa per landgebruik:
 
 ```{r}
-tidy_physeq %>%
+tidy_physeq_rarefied %>%
   tidytacos::tacoplot_venn(Landgebruik_MBAG)
 ```
 
 ```{r}
-tidy_physeq %>%
+tidy_physeq_rarefied %>%
   tidytacos::tacoplot_stack()
 ```
 
 ```{r}
-tidy_physeq %>%
+tidy_physeq_rarefied %>%
   tidytacos::tacoplot_stack(x = Landgebruik_MBAG)
 ```
 
 ```{r}
-tidy_physeq %>%
+tidy_physeq_rarefied %>%
   tidytacos::tacoplot_stack(x = Diepte)
 ```
 

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -70,8 +70,8 @@ path_naar_bestand <- file.path(
     "data",
     "statistiek",
     "Annelida",
-    "phyloseq_Olig01_Annelida",
-    "physeq_Olig01_Annelida_species.Rdata"
+    "phyloseq",
+    "physeq_Olig01_Annelida_species_mbag.Rdata"
   )
 
 load(path_naar_bestand)

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -223,8 +223,11 @@ glimpse(tax_table(physeq_rarefied) %>% as.data.frame %>% as_tibble())
 species <- as.vector(tax_table(physeq)[, "species"])
 species <- species[!grepl("_otu", species)]
 species <- gsub("_", " ", species)
-source("source/r/check_presence.R")
-check_presence(species)
+source(here::here("source/r/check_presence.R"))
+gbif_check <- check_presence(species)
+gbif_check %>%
+filter(!present) %>%
+  kable(caption = "Not present according to GBIF in Western-Europe")
 ```
 
 Unieke en gedeelde taxa per diepte:


### PR DESCRIPTION
toevoegen script voor omzetten phyloseq naar metabaR, gevolgd door metabaR ggtaxplot visualisatie

verschillende bestanden worden weggeschreven en opnieuw ingelezen, wat we hebben proberen aanpassen deze week, maar het lukt niet

de sequenties van de OTUs kunnen we normaal gezien ook uit het phyloseq object halen, met `phyloseq::refseq(physeq)`, maar dan moeten we die ook inladen bij het aanmaken van een phyloseq object, iets wat we tot nu toe nog niet gedaan hebben aangezien dat optioneel is, en we deze voorheen niet nodig hadden in downstream analyse

Om een of andere reden verschenen de commits van de andere pull request hier ook

