### PR TITLE
Effect staalname maand en Poisson distributie op alfa-diversiteit

### DIFF
--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -557,6 +557,77 @@ marginaleffects::plot_predictions(
   labs(y = "Voorspelde aantal taxa")
 ```
 
+## staalname maand meenemen in de modellering van effect landgebruik
+
+We fitten een model waarbij we de log van het totaal aantal reads in een staal als covariaat toevoegen samen met landgebruik en diepte van het staal (de laatste twee in interactie).
+We voegen ook een random intercept toe die aangeeft op welke locatie een staal werd genomen.
+Hiermee geven we aan dat stalen op verschillende diepte, maar dezelfde locatie, gecorreleerd zijn.
+Voor deze analyse, verwijderen we enkele stalen met een laag totaal aantal reads ($\leq 1e+4$).
+
+We modelleren de soortenrijkdom als een Negatief Binomiaal model omdat we verwachten dat deze data overdispersie vertonen ten opzichte van een Poisson verdeling (waar de veronderstelling is dat de variantie gelijk aan het gemiddelde).
+
+```{r m-annelida-richness-2}
+samples_totcount_10k <- tidy_physeq$samples %>%
+  filter(total_count > 1e+4)
+
+form_annelida_richness <- formula(
+  observed ~
+    log(total_count)
+  + Landgebruik_MBAG
+  + Diepte
+  + Maand_staalname
+  + Landgebruik_MBAG:Diepte
+  + Landgebruik_MBAG:Maand_staalname
+  + (1 | Cmon_PlotID)
+  )
+
+m_annelida_richness <- glmmTMB::glmmTMB(
+  formula = form_annelida_richness,
+  data = samples_totcount_10k,
+  family = glmmTMB::nbinom2())
+```
+
+Model validatie toont dat er problemen zijn met de residuele variabiliteit.
+Er lijkt vooral overdispersie (variabiliteit groter dan verwacht) te zijn bij grote waarden van de soortenrijkdom.
+
+
+```{r}
+performance::check_model(m_annelida_richness)
+```
+
+
+```{r m-annelida-richness-summary-2}
+summary(m_annelida_richness)
+```
+
+```{r m-annelida-richness-anova-2}
+car::Anova(m_annelida_richness)
+```
+
+Zoals te verwachten, is het belangrijk om te corrigeren voor het totaal aantal reads:
+
+```{r}
+marginaleffects::plot_predictions(
+  m_annelida_richness,
+  condition = c("total_count"),
+  vcov = vcov(m_annelida_richness)) +
+  labs(y = "Voorspeld aantal taxa") +
+  scale_x_log10()
+```
+
+
+We kunnen nu predicties maken van soortenrijkdom waarbij we controleren voor het totaal aantal reads in een staal:
+
+```{r m-annelida-richness-predictions-2}
+marginaleffects::plot_predictions(
+  m_annelida_richness,
+  condition = c("Landgebruik_MBAG", "Diepte"),
+  vcov = vcov(m_annelida_richness),
+  re.form = NA,
+  type = "response") +
+  labs(y = "Voorspelde aantal taxa")
+```
+
 ## OTU counts 
 
 per phylum

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -85,7 +85,47 @@ Het bestand dat wordt ingelezen is `r basename(path_naar_bestand)`.
 
 ```{r hernoem-object}
 physeq <- physeq_Olig01_Annelida_species
+
+physeq_known_species <- subset_taxa(physeq, !grepl("_otu", tax_table(physeq)[, "species"]))
+physeq_known_genera <- subset_taxa(physeq, !grepl("_otu", tax_table(physeq)[, "genus"]))
 ```
+
+```{r}
+physeq <- physeq %>%
+  microViz::ps_mutate(
+    Datum_staalname = lubridate::mdy_hm(Datum_staalname),
+    Maand_staalname = factor(month(Datum_staalname)),
+    Landgebruik_MBAG = factor(
+    Landgebruik_MBAG,
+    levels = c(
+      "Akker", "Tijdelijk grasland", "Blijvend grasland",
+      "Residentieel grasland", "Natuurgrasland"))
+  )
+
+physeq_known_species <- physeq_known_species %>%
+  microViz::ps_mutate(
+    Datum_staalname = lubridate::mdy_hm(Datum_staalname),
+    Maand_staalname = factor(month(Datum_staalname)),
+    Landgebruik_MBAG = factor(
+    Landgebruik_MBAG,
+    levels = c(
+      "Akker", "Tijdelijk grasland", "Blijvend grasland",
+      "Residentieel grasland", "Natuurgrasland"))
+  )
+
+
+physeq_known_genera <- physeq_known_genera %>%
+  microViz::ps_mutate(
+    Datum_staalname = lubridate::mdy_hm(Datum_staalname),
+    Maand_staalname = factor(month(Datum_staalname)),
+    Landgebruik_MBAG = factor(
+    Landgebruik_MBAG,
+    levels = c(
+      "Akker", "Tijdelijk grasland", "Blijvend grasland",
+      "Residentieel grasland", "Natuurgrasland"))
+  )
+```
+
 
 
 ## Filter en selectie stappen
@@ -428,6 +468,68 @@ conditional_effects(
   m_rarefaction,
     effects = c("Landgebruik_MBAG:Diepte"),
   re.form = NA)
+```
+
+## Test staalname maand ipv landgebruik als verklarende variabele
+
+```{r m-annelida-richness-maand}
+samples_totcount_10k <- tidy_physeq$samples %>%
+  filter(total_count > 1e+4)
+
+form_annelida_richness <- formula(
+  observed ~
+    log(total_count)
+  + Maand_staalname
+  + Diepte
+  + Maand_staalname:Diepte
+  + (1 | Cmon_PlotID)
+  )
+
+m_annelida_richness <- glmmTMB::glmmTMB(
+  formula = form_annelida_richness,
+  data = samples_totcount_10k,
+  family = glmmTMB::nbinom2())
+```
+
+Model validatie toont dat er problemen zijn met de residuele variabiliteit.
+Er lijkt vooral overdispersie (variabiliteit groter dan verwacht) te zijn bij grote waarden van de soortenrijkdom.
+
+
+```{r}
+performance::check_model(m_annelida_richness)
+```
+
+
+```{r m-annelida-richness-summary-maand}
+summary(m_annelida_richness)
+```
+
+```{r m-annelida-richness-anova-maand}
+car::Anova(m_annelida_richness)
+```
+
+Zoals te verwachten, is het belangrijk om te corrigeren voor het totaal aantal reads:
+
+```{r}
+marginaleffects::plot_predictions(
+  m_annelida_richness,
+  condition = c("total_count"),
+  vcov = vcov(m_annelida_richness)) +
+  labs(y = "Voorspeld aantal taxa") +
+  scale_x_log10()
+```
+
+
+We kunnen nu predicties maken van soortenrijkdom waarbij we controleren voor het totaal aantal reads in een staal:
+
+```{r m-annelida-richness-predictions-maand}
+marginaleffects::plot_predictions(
+  m_annelida_richness,
+  condition = c("Maand_staalname", "Diepte"),
+  vcov = vcov(m_annelida_richness),
+  re.form = NA,
+  type = "response") +
+  labs(y = "Voorspelde aantal taxa")
 ```
 
 ## OTU counts 

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -431,6 +431,8 @@ marginaleffects::plot_predictions(
 
 ### Poisson model met correctie voor totaal aantal reads
 
+Poisson distributie lijk toch een betere fit voor alfa-diversiteit Annelida (zie notes meeting 18/04/2024)?
+
 ```{r m-annelida-richness-poisson}
 samples_totcount_10k <- tidy_physeq$samples %>%
   filter(total_count > 1e+4)

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -429,6 +429,70 @@ marginaleffects::plot_predictions(
 ```
 
 
+### Poisson model met correctie voor totaal aantal reads
+
+```{r m-annelida-richness-poisson}
+samples_totcount_10k <- tidy_physeq$samples %>%
+  filter(total_count > 1e+4)
+
+form_annelida_richness <- formula(
+  observed ~
+    log(total_count)
+  + Landgebruik_MBAG
+  + Diepte
+  + Landgebruik_MBAG:Diepte
+  + (1 | Cmon_PlotID)
+  )
+
+m_annelida_richness <- glmmTMB::glmmTMB(
+  formula = form_annelida_richness,
+  data = samples_totcount_10k,
+  family = poisson())
+```
+
+Model validatie toont dat er problemen zijn met de residuele variabiliteit.
+Er lijkt vooral overdispersie (variabiliteit groter dan verwacht) te zijn bij grote waarden van de soortenrijkdom.
+
+
+```{r}
+performance::check_model(m_annelida_richness)
+```
+
+
+```{r m-annelida-richness-summary-poisson}
+summary(m_annelida_richness)
+```
+
+```{r m-annelida-richness-anova-poisson}
+car::Anova(m_annelida_richness)
+```
+
+Zoals te verwachten, is het belangrijk om te corrigeren voor het totaal aantal reads:
+
+```{r}
+marginaleffects::plot_predictions(
+  m_annelida_richness,
+  condition = c("total_count"),
+  vcov = vcov(m_annelida_richness)) +
+  labs(y = "Voorspeld aantal taxa") +
+  scale_x_log10()
+```
+
+
+We kunnen nu predicties maken van soortenrijkdom waarbij we controleren voor het totaal aantal reads in een staal:
+
+```{r m-annelida-richness-predictions-poisson}
+marginaleffects::plot_predictions(
+  m_annelida_richness,
+  condition = c("Landgebruik_MBAG", "Diepte"),
+  vcov = vcov(m_annelida_richness),
+  re.form = NA,
+  type = "response") +
+  labs(y = "Voorspelde aantal taxa")
+```
+
+
+
 ### Rarefaction analyse 
 
 Dit is een alternatief voor voorgaande analyse.

--- a/source/rmarkdown/annelida_data_analyse.Rmd
+++ b/source/rmarkdown/annelida_data_analyse.Rmd
@@ -221,11 +221,36 @@ tidy_physeq$samples %>%
   kable()
 ```
 
+Inclusief moment (maand) van staalname:
+
+```{r designvars}
+tidy_physeq$samples %>%
+  count(Diepte, Landgebruik_MBAG, Maand_staalname) %>%
+  kable()
+```
+
+Zonder diepte:
+
+```{r designvars}
+tidy_physeq$samples %>%
+  count(Landgebruik_MBAG, Maand_staalname) %>%
+  kable()
+```
+
 Aantal bodemlocaties:
 
 ```{r}
 tidy_physeq$samples %>%
   group_by(Landgebruik_MBAG) %>%
+  summarise(n_locaties = n_distinct(Cmon_PlotID)) %>%
+  kable()
+```
+
+Aantal per maand:
+
+```{r}
+tidy_physeq$samples %>%
+  group_by(Maand_staalname) %>%
   summarise(n_locaties = n_distinct(Cmon_PlotID)) %>%
   kable()
 ```


### PR DESCRIPTION
1. Variabele `Maand_staalname` toegevoegd aan sample data phyloseq object
2. Deze ook toegevoegd in verkenning designvariabelen
3. alfa-diversiteit eens gelopen met `Maand_staalname` ipv `Landgebruik_MBAG`
4. 1e poging `Maand_staalname` meenemen in de modellering van effect landgebruik (samen met Diepte en aantal reads). Interactie `Landgebruik_MBAG` met `Maand_staalname` hier ook nodig? Voorlopig in aparte chunk gezet en originele alfa-div modellering dus niet aangepast
6. aparte chunk met alfa-diversiteit modellering obv `Poisson` ipv `glmmTMB::nbinom2`, maar nog zonder `Maand_staalname`