### PR TITLE
Update GBIF check presence

### DIFF
--- a/source/r/check_presence.R
+++ b/source/r/check_presence.R
@@ -1,19 +1,18 @@
 #' Deze functie gaat na of een soort volgens GBIF voorkomt in een gekozen set
 #' van landen # nolint start
 #'
-#' Default zijn West-Europese landen ingesteld: België, Frankrijk, Duitsland,
-#' Luxemburg, Nederland, Zwitserland, Oostenrijk
+#' Default zijn Europese landen ingesteld: Albania, Andorra, Austria, Belarus, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Czechia, Denmark, Estonia, Finland, France, Germany, Greece, Hungary, Ireland, Italy, Kosovo, Latvia, Liechtenstein, Lithuania, Luxembourg, Monaco, Montenegro, Netherlands, North Macedonia, Norway, Poland, Portugal, Romania, San Marino, Serbia, Slovakia, Slovenia, Spain, Sweden, Switzerland, Ukraine, United Kingdom
 #'
 #' @param input A character vector of Scientific names or a .txt file from which
 #' Scientific Names can be read.
 #' @param countries a character vector of country codes
 #'
 #' @example
-#' result_WestEurope <- check_presence_from_file()
-#' print(result_WestEurope) # nolint end
+#' result_Europe <- check_presence_from_file()
+#' print(result_Europe) # nolint end
 check_presence <- function(
     input = NULL,
-    countries = c("BE", "FR", "DE", "LU", "NL", "CH", "AT")) {
+    countries = c("AL", "AD", "AT", "BY", "BE", "BA", "BG", "HR", "CZ", "DK", "EE", "FI", "FR", "DE", "GR"  ,"HU", "IE", "IT", "XK", "LV", "LI", "LT", "LU", "MC", "ME", "NL", "MK", "NO", "PL", "PT", "RO", "SM", "RS", "SK", "SI", "ES", "SE", "CH", "UA", "UK")) {
   require(dplyr)
   require(purrr)
   if (length(input) == 1 && !is.null(input) && file.exists(input)) {
@@ -35,23 +34,20 @@ check_presence <- function(
   for (country in countries) {
     # Function to check occurrence data and handle errors
     check_occurrence <- function(name) {
-      data <- tryCatch(
-        {
-          rgbif::occ_data(
-            scientificName = name,
-            country = country, # Specify one country at a time
-            limit = 1
-          )
-        },
-        error = function(e) {
-          return(list(error = TRUE))
-        }
-      )
+      data <- tryCatch({
+        rgbif::occ_data(
+          scientificName = name,
+          country = country,  # Specify one country at a time
+          limit = 1
+        )
+      }, error = function(e) {
+        return(list(error = TRUE))
+      })
 
       if (inherits(data, "error") || is.null(data$data)) {
-        return(FALSE) # Occurrence data is not present or error occurred
+        return(FALSE)  # Occurrence data is not present or error occurred
       } else {
-        return(TRUE) # Occurrence data is present
+        return(TRUE)   # Occurrence data is present
       }
     }
 


### PR DESCRIPTION
Uitbreiding GBIF check presence naar heel `Europa` ipv `West-Europa` (na overleg met o.a. Jan Soors voor de Annelida)

Goal is here to flag taxonomic identifications of taxa that have not yet been detected in Europe before according to GBIF

A more local (e.g. Benelux) GBIF check can perhaps be implemented in a later phase, but for the current R&D stage of the eDNA metabarcoding workflow in soil, the idea here is to evaluate whether or not certain primers that were tested detect highely unlikely taxa

Atm there seems to be 2 problems with the script:

https://github.com/inbo/mbag-bodem/issues/38
https://github.com/inbo/mbag-bodem/issues/37

History of the script:

https://github.com/inbo/mbag-bodem/pull/7
https://github.com/inbo/mbag-bodem/pull/4